### PR TITLE
Fixes for bot only checking the website for images when it starts

### DIFF
--- a/main.py
+++ b/main.py
@@ -165,6 +165,13 @@ async def on_guild_join(guild: discord.Guild):
     await c.send(embed=embed)
 
 
+@client.event
+async def on_guild_remove(guild: discord.Guild):
+    guildInfo = loadGuildInfo()
+    guildInfo.pop(str(guild.id), None)
+    saveGuildInfo(guildInfo)
+
+
 try:
     client.run(os.getenv("BOT_TOKEN"))
 except discord.HTTPException as e:

--- a/main.py
+++ b/main.py
@@ -168,18 +168,11 @@ async def on_ready():
 @client.event
 async def on_guild_join(guild: discord.Guild):
     c = guild.system_channel
-    embed = discord.Embed()
-    guildInfo = loadGuildInfo()
-    if str(guild.id) in guildInfo and guildInfo[str(guild.id)]["channel"]:
-        embed.add_field(
-            name="Thanks for adding the Big Watermelon bot to your server",
-            value=f"This bot has been previously setup on this server. Updates will be posted to <#{guildInfo[str(guild.id)]['channel']}>",
-        )
-    else:
-        embed.add_field(
-            name="Thanks for adding the Big Watermelon bot to your server",
-            value="To start using the bot, please use /setchannel to set a channel to post updates",
-        )
+    embed = discord.Embed(color=discord.Colour.blue)
+    embed.add_field(
+        name="Thanks for adding the Big Watermelon bot to your server",
+        value="To start using the bot, please use /setchannel to set a channel to post updates",
+    )
     await c.send(embed=embed)
 
 


### PR DESCRIPTION
Also:
- Reverted to using a single task loop rather than a separate one for each server, for simplicity's sake
- Guild info is deleted when being kicked/banned from a guild